### PR TITLE
Get the derivative of the loss function out of the for loop

### DIFF
--- a/mla/linear_models.py
+++ b/mla/linear_models.py
@@ -87,10 +87,9 @@ class BasicRegression(BaseEstimator):
     def _gradient_descent(self):
         theta = self.theta
         errors = [self._cost(self.X, self.y, theta)]
-
+        # Get derivative of the loss function
+        cost_d = grad(self._loss)
         for i in range(1, self.max_iters + 1):
-            # Get derivative of the loss function
-            cost_d = grad(self._loss)
             # Calculate gradient and update theta
             delta = cost_d(theta)
             theta -= self.lr * delta


### PR DESCRIPTION
I think getting the derivative of the loss function should be out of the for loop. There is no need to calculate the derivative function for max iteration times.